### PR TITLE
Explicitly initialize UserConfig values to avoid undefined dereference.

### DIFF
--- a/list.rb
+++ b/list.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 Plugin.create :list do
+  UserConfig[:retrieve_interval_list_timeline] ||= 60
   defevent :list_created, priority: :routine_passive, prototype: [Diva::Model, Array]
   defevent :list_destroy, priority: :routine_passive, prototype: [Diva::Model, Array]
 


### PR DESCRIPTION
https://github.com/mikutter/rest/issues/1
で挙がった UserConfig の interval 値の初期値追加です